### PR TITLE
Fix code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -79,8 +79,11 @@ func (t *Transport) UnpackBytes() (raw []byte, err error) {
 		return nil, err
 	}
 	var size int64
-	if size, err = strconv.ParseInt(length, 16, 64); err != nil {
+	if size, err = strconv.ParseInt(length, 16, 32); err != nil {
 		return nil, err
+	}
+	if size < 0 || size > int64(int(^uint(0)>>1)) {
+		return nil, fmt.Errorf("size out of bounds: %d", size)
 	}
 
 	raw, err = t.ReadBytesN(int(size))


### PR DESCRIPTION
Fixes [https://github.com/julien-noblet/gadb/security/code-scanning/2](https://github.com/julien-noblet/gadb/security/code-scanning/2)

To fix the problem, we need to ensure that the parsed integer value fits within the bounds of the `int` type before performing the conversion. This can be achieved by adding a bounds check after parsing the integer. Specifically, we should check that the parsed value is within the range of the `int` type and handle cases where it is not.

The best way to fix this issue without changing existing functionality is to:
1. Parse the integer using `strconv.ParseInt` with a bit size of 32, which directly fits into the `int` type on most platforms.
2. Add bounds checking to ensure the parsed value is within the range of the `int` type before converting.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
