### PR TITLE
Fix code scanning alert no. 1: Incorrect conversion between integer types

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"math"
 )
 
 const (
@@ -71,6 +72,9 @@ func (c Client) ServerVersion() (version int, err error) {
 		return 0, err
 	}
 
+	if v < math.MinInt || v > math.MaxInt {
+		return 0, fmt.Errorf("parsed value out of int range: %d", v)
+	}
 	version = int(v)
 	return
 }


### PR DESCRIPTION
Fixes [https://github.com/julien-noblet/gadb/security/code-scanning/1](https://github.com/julien-noblet/gadb/security/code-scanning/1)

To fix the problem, we need to ensure that the value parsed by `strconv.ParseInt` fits within the bounds of the `int` type before performing the conversion. This can be done by checking if the parsed value is within the range of the `int` type on the current platform.

1. Use `strconv.ParseInt` with a bit size of 32 to directly parse the value into a 32-bit integer if the target type is `int32`.
2. Alternatively, if the target type is `int` and we need to support both 32-bit and 64-bit systems, we should check the bounds of the `int` type before converting.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
